### PR TITLE
Be able to link on macOS

### DIFF
--- a/tools/callgraph-profiler/main.cpp
+++ b/tools/callgraph-profiler/main.cpp
@@ -253,7 +253,9 @@ prepareLinkingPaths(SmallString<32> invocationPath) {
   libPaths.push_back(TEMP_LIBRARY_PATH "/Release/lib/");
 #endif
   libraries.push_back(RUNTIME_LIB);
+#ifndef __APPLE__
   libraries.push_back("rt");
+#endif
 }
 
 


### PR DESCRIPTION
When our profiler attempts to link on macOS, it crashes. This is because it is unable to find librt.

Although this is pull request is mildly bikeshedding, but it would definitely help the folks in the class whom are using MacBooks to develop on (myself included); they can work on the project while on the go (of course, there's also the option of using a VM, but that comes at a cost of RAM, disk, and battery usage).